### PR TITLE
integrate summary_saver to save AI output to JSON

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import send_prompt_online
 import json
+import summary_saver
 
 with open("../python_test/bible.txt", "r", encoding="utf-8") as file:
     text = file.read()
@@ -13,3 +14,6 @@ print(text["keywords"])
 print(text["topics"])
 tokens = output.usage_metadata.total_token_count
 print(f"Number of tokens used: {tokens}")
+
+saved_path = summary_saver.save_summary(text)
+print(f"\nSuccess! Summary saved to: {saved_path}")


### PR DESCRIPTION
Add functionality to save AI analysis to JSON

I updated src/main.py to use the summary_saver.py module. The script now successfully takes the AI's output and saves the summary, keywords, and topics to output/summary/summary.json